### PR TITLE
Remove wrong use of static attribute

### DIFF
--- a/rt-neural-generic/src/rt-neural-generic.cpp
+++ b/rt-neural-generic/src/rt-neural-generic.cpp
@@ -33,8 +33,7 @@ float RtNeuralGeneric::rampValue(float start, float end, uint32_t n_samples, uin
 
 // Apply a gain ramp to a buffer
 void RtNeuralGeneric::applyGainRamp(float *out, const float *in, float start, float end, uint32_t n_samples) {
-    static uint32_t i;
-    for(i=0; i<n_samples; i++) {
+    for(uint32_t i=0; i<n_samples; i++) {
         out[i] = in[i] * rampValue(start, end, n_samples, i);
     }
 }
@@ -42,8 +41,7 @@ void RtNeuralGeneric::applyGainRamp(float *out, const float *in, float start, fl
 /**********************************************************************************************************************************************************/
 
 void RtNeuralGeneric::applyBiquadFilter(float *out, const float *in, Biquad *filter, uint32_t n_samples) {
-    static uint32_t i;
-    for(i=0; i<n_samples; i++) {
+    for(uint32_t i=0; i<n_samples; i++) {
         out[i] = filter->process(in[i]);
     }
 }


### PR DESCRIPTION
Fixes the issue reported in #9

Seems obvious now looking at it, why was `static` used there in the first place?