### PR TITLE
Add modgui:discussionURL for the forum post related to the plugin

### DIFF
--- a/rt-neural-generic/ttl/modgui.ttl
+++ b/rt-neural-generic/ttl/modgui.ttl
@@ -12,6 +12,7 @@
         modgui:label "rt-neural-gen" ;
         modgui:model "combo-model-001" ;
         modgui:panel "0550" ;
+        modgui:discussionURL <https://forum.mod.audio/t/new-neural-lv2-plugin-from-aida-dsp-based-extensively-on-existing-neuralpi-reduced-to-the-bone/8047> ;
         modgui:port [
             lv2:index 0 ;
             lv2:symbol "PREGAIN" ;


### PR DESCRIPTION
This adds a "See discussion" button on the plugin info dialog.
