### PR TITLE
Ensure we use state:mapPath correctly

### DIFF
--- a/rt-neural-generic/src/rt-neural-generic.cpp
+++ b/rt-neural-generic/src/rt-neural-generic.cpp
@@ -449,6 +449,9 @@ void RtNeuralGeneric::connect_port(LV2_Handle instance, uint32_t port, void *dat
         case INPUT_SIZE:
             self->input_size = (float*) data;
             break;
+        case PLUGIN_ENABLED:
+            self->enabled = (float*) data;
+            break;
     }
 }
 
@@ -465,13 +468,14 @@ void RtNeuralGeneric::run(LV2_Handle instance, uint32_t n_samples)
     float in_lpf_pc = *self->in_lpf_pc;
     float eq_position = *self->eq_position;
     float eq_bypass = *self->eq_bypass;
+    bool enabled = *self->enabled > 0.5f;
 #if AIDADSP_CONDITIONED_MODELS
     const float param1 = *self->param1;
     const float param2 = *self->param2;
 #endif
 
     self->preGain.setTargetValue(pregain);
-    self->masterGain.setTargetValue(master);
+    self->masterGain.setTargetValue(enabled ? master : 0.f);
 
     if (in_lpf_pc != self->in_lpf_pc_old) { /* Update filter coeffs */
         self->in_lpf->setBiquad(bq_type_lowpass, MAP(in_lpf_pc, 0.0f, 100.0f, INLPF_MAX_CO, INLPF_MIN_CO), 0.707f, 0.0f);

--- a/rt-neural-generic/src/rt-neural-generic.h
+++ b/rt-neural-generic/src/rt-neural-generic.h
@@ -61,6 +61,7 @@ typedef enum {
     EQ_BYPASS, EQ_POS, BASS, BFREQ, MID, MFREQ, MIDQ, MTYPE, TREBLE, TFREQ, DEPTH, PRESENCE,
     MASTER,
     INPUT_SIZE,
+    PLUGIN_ENABLED,
     PLUGIN_PORT_COUNT} ports_t;
 
 // Everything needed to run a model
@@ -183,6 +184,7 @@ public:
     float presence_boost_db_old;
     float *eq_bypass;
     float *input_size;
+    float *enabled;
 
     // to be used for reporting input_size to GUI (0 for error/unloaded, otherwise matching input_size)
     int last_input_size;

--- a/rt-neural-generic/ttl/rt-neural-generic.ttl
+++ b/rt-neural-generic/ttl/rt-neural-generic.ttl
@@ -288,6 +288,16 @@ lv2:port
     lv2:scalePoint [rdfs:label "SNAPSHOT"; rdf:value 1];
     lv2:scalePoint [rdfs:label "WITH 1 PARAM"; rdf:value 2];
     lv2:scalePoint [rdfs:label "WITH 2 PARAMS"; rdf:value 3];
+],
+[
+    a lv2:ControlPort, lv2:InputPort;
+    lv2:index 23;
+    lv2:symbol "enabled";
+    lv2:name "Enabled";
+    lv2:default 1;
+    lv2:minimum 0;
+    lv2:maximum 1;
+    lv2:designation lv2:enabled;
 ];
 
 state:state [

--- a/rt-neural-generic/ttl/rt-neural-generic.ttl
+++ b/rt-neural-generic/ttl/rt-neural-generic.ttl
@@ -54,7 +54,7 @@ lv2:project <http://lv2plug.in/ns/lv2>;
 lv2:requiredFeature urid:map ,
     work:schedule ;
 lv2:optionalFeature lv2:hardRTCapable ,
-    state:loadDefaultState ;
+    state:loadDefaultState, state:mapPath ;
 lv2:extensionData state:interface ,
     work:interface ;
 patch:writable <http://aidadsp.cc/plugins/aidadsp-bundle/rt-neural-generic#json>;


### PR DESCRIPTION
Feature was missing from the LV2 ttl, and also only handled absolute->abstract paths, not the other way around.

Also added a lv2:enabled control, needed for mod-host to save state when the plugin is bypassed.
