### PR TITLE
Fix win32 install

### DIFF
--- a/rt-neural-generic/CMakeLists.txt
+++ b/rt-neural-generic/CMakeLists.txt
@@ -51,7 +51,7 @@ set(LV2_INSTALL_DIR ${DESTDIR}${PREFIX}/rt-neural-generic.lv2)
 
 # config install
 install(TARGETS rt-neural-generic
-    LIBRARY
+    LIBRARY RUNTIME
     DESTINATION ${LV2_INSTALL_DIR}
 )
 

--- a/rt-neural-generic/CMakeLists.txt
+++ b/rt-neural-generic/CMakeLists.txt
@@ -51,7 +51,6 @@ set(LV2_INSTALL_DIR ${DESTDIR}${PREFIX}/rt-neural-generic.lv2)
 
 # config install
 install(TARGETS rt-neural-generic
-    LIBRARY RUNTIME
     DESTINATION ${LV2_INSTALL_DIR}
 )
 


### PR DESCRIPTION
on windows the `LIBRARY` option tries to install *.a files, which are useless for plugins. we need to install the `RUNTIME` instead, which is the *.dll used for plugins.
dont think this has any side effects for linux builds.

this fixes aidadsp-lv2 for use in mod-app
