### PR TITLE
Make the DC blocker and AA filters optional

### DIFF
--- a/rt-neural-generic/src/rt-neural-generic.h
+++ b/rt-neural-generic/src/rt-neural-generic.h
@@ -18,6 +18,11 @@
 #define AIDADSP_CONDITIONED_MODELS 1
 #endif
 
+// DC blocker is optional for model loader
+#ifdef AIDADSP_MODEL_LOADER
+#define AIDADSP_OPTIONAL_DCBLOCKER 1
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -59,6 +64,9 @@ typedef enum {
     PARAM1, PARAM2,
 #endif
     EQ_BYPASS, EQ_POS, BASS, BFREQ, MID, MFREQ, MIDQ, MTYPE, TREBLE, TFREQ, DEPTH, PRESENCE,
+#if AIDADSP_OPTIONAL_DCBLOCKER
+    DCBLOCKER,
+#endif
     MASTER,
     INPUT_SIZE,
     PLUGIN_ENABLED,
@@ -154,6 +162,9 @@ public:
 #if AIDADSP_CONDITIONED_MODELS
     float *param1;
     float *param2;
+#endif
+#if AIDADSP_OPTIONAL_DCBLOCKER
+    float *dc_blocker_param;
 #endif
     float *master_db;
     ExponentialValueSmoother masterGain;

--- a/rt-neural-generic/ttl/rt-neural-generic.ttl
+++ b/rt-neural-generic/ttl/rt-neural-generic.ttl
@@ -98,6 +98,7 @@ lv2:port
     lv2:minimum 0;
     lv2:maximum 100.0;
     units:unit units:pc;
+    lv2:scalePoint [rdfs:label "Off"; rdf:value 0];
 ],
 [
     a lv2:ControlPort, lv2:InputPort;
@@ -267,6 +268,17 @@ lv2:port
 [
     a lv2:ControlPort, lv2:InputPort;
     lv2:index 21;
+    lv2:symbol "DCBLOCKER";
+    lv2:name "DCBLOCKER";
+    lv2:default 1;
+    lv2:minimum 0;
+    lv2:maximum 1;
+    lv2:portProperty lv2:integer;
+    lv2:portProperty lv2:toggled;
+],
+[
+    a lv2:ControlPort, lv2:InputPort;
+    lv2:index 22;
     lv2:symbol "MASTER";
     lv2:name "OUTPUT";
     lv2:default 0;
@@ -276,7 +288,7 @@ lv2:port
 ],
 [
     a lv2:ControlPort, lv2:OutputPort;
-    lv2:index 22;
+    lv2:index 23;
     lv2:symbol "ModelInSize";
     lv2:name "Model Input Size";
     lv2:default 0;
@@ -291,7 +303,7 @@ lv2:port
 ],
 [
     a lv2:ControlPort, lv2:InputPort;
-    lv2:index 23;
+    lv2:index 24;
     lv2:symbol "enabled";
     lv2:name "Enabled";
     lv2:default 1;


### PR DESCRIPTION
Only applies to the loader, so that the commercial plugins can continue to work as-is.

The AA filter is fully turned off when at 0%.
